### PR TITLE
Fix readme example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const persistMiddleware = getPersistMiddleware({
   // a function to call to persist stuff.
   // This *must* return a Promise and
   // *must take two arguments: (key, value)*
-  cacheFunction: cache.set,
+  cacheFn: cache.set,
   // optionally logs out which action triggered
   // something to be cached and what reducers
   // were persisted as a result.


### PR DESCRIPTION
The readme references the `cacheFunction` config property, which gave me an error when trying it out.

<img width="439" alt="screen shot 2018-04-18 at 23 43 13" src="https://user-images.githubusercontent.com/303731/38957164-7ec59e1a-4362-11e8-942e-c5e1ba527cfd.png">

Looks like [the property is actually called](https://github.com/HenrikJoreteg/redux-persist-middleware/blob/ca440bf2c3e85b9166b8deb36ac4e43600a20a95/index.js#L18) `cacheFn`.
This PR just updates the docs to correct this.